### PR TITLE
pullup for printer_in on AQ+Mini

### DIFF
--- a/System/fpga/src/top.ucf
+++ b/System/fpga/src/top.ucf
@@ -98,6 +98,8 @@ NET "hc2[6]"            LOC = P93;
 NET "hc2[7]"            LOC = P88;
 NET "hc2[8]"            LOC = P85;
 
+NET "printer_in" PULLUP;
+
 NET "ebus_d[0]" PULLUP;
 NET "ebus_d[1]" PULLUP;
 NET "ebus_d[2]" PULLUP;


### PR DESCRIPTION
Fix to allow LPRINT etc to work on the AQ+ Mini without a printer
